### PR TITLE
cancro: input: atmel_mtx_ts: properly set irq_enabled

### DIFF
--- a/drivers/input/touchscreen/atmel_mxt_ts.c
+++ b/drivers/input/touchscreen/atmel_mxt_ts.c
@@ -597,6 +597,7 @@ struct mxt_data {
 	bool is_ignore_channel_saved;
 	bool init_complete;
 	bool use_last_golden;
+	bool irq_enabled;
 	struct mutex golden_mutex;
 	bool keys_off;
 
@@ -758,6 +759,22 @@ static u8 mxt_read_chg(struct mxt_data *data)
 
 	u8 val = (u8)gpio_get_value(gpio_intr);
 	return val;
+}
+
+static void mxt_disable_irq(struct mxt_data *data)
+{
+	if (likely(data->irq_enabled)) {
+		disable_irq(data->irq);
+		data->irq_enabled = false;
+	}
+}
+
+static void mxt_enable_irq(struct mxt_data *data)
+{
+	if (likely(!data->irq_enabled)) {
+		enable_irq(data->irq);
+		data->irq_enabled = true;
+	}
 }
 
 static int mxt_wait_for_chg(struct mxt_data *data)
@@ -3426,7 +3443,7 @@ static ssize_t mxt_update_fw_store(struct device *dev,
 	}
 
 	dev_info(dev, "Identify firmware name :%s \n", fw_name);
-	disable_irq(data->irq);
+	mxt_disable_irq(data);
 
 	error = mxt_load_fw(dev, fw_name);
 	if (error) {
@@ -3447,7 +3464,7 @@ static ssize_t mxt_update_fw_store(struct device *dev,
 	}
 
 	if (data->state == APPMODE) {
-		enable_irq(data->irq);
+		mxt_enable_irq(data);
 	}
 
 	kfree(fw_name);
@@ -4943,7 +4960,7 @@ static int mxt_suspend(struct device *dev)
 	struct mxt_data *data = i2c_get_clientdata(client);
 	struct input_dev *input_dev = data->input_dev;
 
-	disable_irq(client->irq);
+	mxt_disable_irq(data);
 
 	data->safe_count = 0;
 	cancel_delayed_work_sync(&data->update_setting_delayed_work);
@@ -5008,7 +5025,7 @@ static int mxt_resume(struct device *dev)
 
 	mutex_unlock(&input_dev->mutex);
 
-	enable_irq(client->irq);
+	mxt_enable_irq(data);
 
 	return 0;
 }
@@ -5759,6 +5776,7 @@ static int __devinit mxt_probe(struct i2c_client *client,
 		goto err_free_input_device;
 	}
 
+	data->irq_enabled = true;
 	error = sysfs_create_group(&client->dev.kobj, &mxt_attr_group);
 	if (error) {
 		dev_err(&client->dev, "Failure %d creating sysfs group\n",
@@ -5867,7 +5885,7 @@ static void mxt_shutdown(struct i2c_client *client)
 {
 	struct mxt_data *data = i2c_get_clientdata(client);
 
-	disable_irq(data->irq);
+	mxt_disable_irq(data);
 	data->state = SHUTDOWN;
 }
 


### PR DESCRIPTION
[   47.623427] ------------[ cut here ]------------
[   47.623438] WARNING: at /git/lineage-14.1/kernel/xiaomi/cancro/kernel/irq/manage.c:428 enable_irq+0x68/0x7c()
[   47.623440] Unbalanced enable for IRQ 344
[   47.623443] Modules linked in:
[   47.623443]
[   47.623456] [<c010eec8>] (unwind_backtrace+0x0/0x138) from [<c01a9b4c>] (warn_slowpath_fmt+0x58/0x7c)
[   47.623463] [<c01a9b4c>] (warn_slowpath_fmt+0x58/0x7c) from [<c020c57c>] (enable_irq+0x68/0x7c)
[   47.623471] [<c020c57c>] (enable_irq+0x68/0x7c) from [<c05da468>] (fb_notifier_cb+0x104/0x2ec)
[   47.623481] [<c05da468>] (fb_notifier_cb+0x104/0x2ec) from [<c01cde18>] (notifier_call_chain+0x40/0x68)
[   47.623488] [<c01cde18>] (notifier_call_chain+0x40/0x68) from [<c01ce0a0>] (__blocking_notifier_call_chain+0x40/0x58)
[   47.623493] [<c01ce0a0>] (__blocking_notifier_call_chain+0x40/0x58) from [<c01ce0cc>] (blocking_notifier_call_chain+0x14/0x1c)
[   47.623502] [<c01ce0cc>] (blocking_notifier_call_chain+0x14/0x1c) from [<c03f73d4>] (fb_blank+0x5c/0x68)
[   47.623508] [<c03f73d4>] (fb_blank+0x5c/0x68) from [<c03f7d1c>] (do_fb_ioctl+0x550/0x5d4)
[   47.623518] [<c03f7d1c>] (do_fb_ioctl+0x550/0x5d4) from [<c0283b70>] (do_vfs_ioctl+0x494/0x58c)
[   47.623525] [<c0283b70>] (do_vfs_ioctl+0x494/0x58c) from [<c0283cb4>] (sys_ioctl+0x4c/0x70)
[   47.623532] [<c0283cb4>] (sys_ioctl+0x4c/0x70) from [<c0108980>] (ret_fast_syscall+0x0/0x30)
[   47.623535] ---[ end trace da227214a82491ba ]---

Change-Id: I084a157ff4f6a8ef9e24ad4bcbf08458acb3ff99
Signed-off-by: Joey Rizzoli <joey@lineageos.it>